### PR TITLE
Update use of OMOP ES cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       OMOP_ES_BATCHED: "${BATCHED}"
       OMOP_ES_OUTPUT_DIRECTORY: "${OUTPUT_DIRECTORY}"
       OMOP_ES_ZIP_OUTPUT: "${ZIP_OUTPUT}"
+      TZ: Europe/London
     volumes:
       - "./extract:/app/extract"
 
@@ -51,5 +52,6 @@ services:
     environment:
       <<: *proxy-common
       CRDM_ID: "${CRDM_ID}"
+      TZ: Europe/London
     volumes:
       - "./omop-cascade/local:/share/local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,7 @@ services:
       <<: *proxy-common
       OMOP_ES_SETTINGS_ID: "${SETTINGS_ID}"
       OMOP_ES_BATCHED: "${BATCHED}"
-      OMOP_ES_START_BATCH: "${START_BATCH}"
-      OMOP_ES_EXTRACT_DT: "${EXTRACT_DT}"
+      OMOP_ES_OUTPUT_DIRECTORY: "${OUTPUT_DIRECTORY}"
       OMOP_ES_ZIP_OUTPUT: "${ZIP_OUTPUT}"
     volumes:
       - "./extract:/app/extract"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,6 @@ FROM base AS omop_es-builder
 
 ARG OMOP_ES_BRANCH=master
 ARG GITHUB_PAT
-RUN echo "tmp3"
 RUN git clone -b ${OMOP_ES_BRANCH} https://${GITHUB_PAT}@github.com/uclh-criu/omop_es.git ./omop_es
 
 WORKDIR /app/omop_es

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ FROM base AS omop_es-builder
 
 ARG OMOP_ES_BRANCH=master
 ARG GITHUB_PAT
-
+RUN echo "tmp3"
 RUN git clone -b ${OMOP_ES_BRANCH} https://${GITHUB_PAT}@github.com/uclh-criu/omop_es.git ./omop_es
 
 WORKDIR /app/omop_es
@@ -84,6 +84,9 @@ RUN Rscript -e "renv::restore()" || \
 
 RUN Rscript omop_metadata/download_omop_metadata.R && \
     Rscript source_access/UCLH/mock_database/recreate_mockdb.R
+# Allow for an extra pull if the branch is updated without having to do renv restore from the start
+RUN git pull origin ${OMOP_ES_BRANCH}
+RUN Rscript -e "renv::restore()"
 
 # Final omop_es iamge
 FROM base AS omop_es

--- a/docker/omop_es.sh
+++ b/docker/omop_es.sh
@@ -22,7 +22,7 @@ if [ "$OMOP_ES_BATCHED" = true ]; then
     echo "Running batched omop_es..."
     CMD="Rscript $MAIN_BATCHED --settings_id $OMOP_ES_SETTINGS_ID"
     # Add on extra CLI arguments if they're filled
-    [ -n "$OMOP_ES_OUTPUT_DIRECTORY" ] && CMD="$CMD --output-directory $OMOP_ES_OUTPUT_DIRECTORY"
+    [ -n "$OMOP_ES_OUTPUT_DIRECTORY" ] && CMD="$CMD --output_directory $OMOP_ES_OUTPUT_DIRECTORY"
 else
     CMD="Rscript $MAIN_COMMAND --settings_id $OMOP_ES_SETTINGS_ID"
     ## Add on extra CLI arguments if they're filled

--- a/docker/omop_es.sh
+++ b/docker/omop_es.sh
@@ -7,8 +7,8 @@ set -euxo pipefail
 OMOP_ES_DIR="omop_es"
 
 # The following variables are relative to the OMOP_ES directory
-MAIN_BATCHED="./main_batched.R"
-MAIN_COMMAND="./main_command.R"
+MAIN_BATCHED="./main/batched.R"
+MAIN_COMMAND="./main/command.R"
 
 # Move to the OMOP_ES directory
 cd $OMOP_ES_DIR
@@ -22,7 +22,7 @@ if [ "$OMOP_ES_BATCHED" = true ]; then
     echo "Running batched omop_es..."
     CMD="Rscript $MAIN_BATCHED --settings_id $OMOP_ES_SETTINGS_ID"
     # Add on extra CLI arguments if they're filled
-    [ -n "$OMOP_ES_START_BATCH" ] && [ -n "$OMOP_ES_EXTRACT_DT" ] && CMD="$CMD --start_batch $OMOP_ES_START_BATCH --extract_dt $OMOP_ES_EXTRACT_DT"
+    [ -n "$OMOP_ES_OUTPUT_DIRECTORY" ] && CMD="$CMD --output-directory $OMOP_ES_OUTPUT_DIRECTORY"
 else
     CMD="Rscript $MAIN_COMMAND --settings_id $OMOP_ES_SETTINGS_ID"
     ## Add on extra CLI arguments if they're filled


### PR DESCRIPTION
We've made some breaking changes to main branch so this fixes that (sorry!). 

Also testing out being able to only call batch process with the output directory name: [omop_es/stefpiatek/344-batch-rerun-using-same-args](https://github.com/uclh-criu/omop_es/tree/stefpiatek/344-batch-rerun-using-same-args).

Will update on here when it works, but will also need to update how we're calling batch processing in prefect

Resolves #29 