### PR TITLE
Can't pass `dry_run` in there any more.

### DIFF
--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -32,9 +32,8 @@ def run_omop_es(
     zip_output: Optional[bool] = False,
     start_batch: Optional[str] = None,
     extract_dt: Optional[str] = None,
-    dry_run: bool = False,  # could remove?
 ) -> None:
-    build_docker(ROOT_PATH, build_args=build_args, dry_run=dry_run)
+    build_docker(ROOT_PATH, build_args=build_args)
     run_omop_es_docker(
         working_dir=ROOT_PATH,
         batched=batched,

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -32,7 +32,7 @@ def run_omop_es(
     zip_output: Optional[bool] = False,
     start_batch: Optional[str] = None,
     extract_dt: Optional[str] = None,
-    dry_run: bool = False,
+    dry_run: bool = False,  # could remove?
 ) -> None:
     build_docker(ROOT_PATH, build_args=build_args, dry_run=dry_run)
     run_omop_es_docker(
@@ -42,7 +42,6 @@ def run_omop_es(
         zip_output=zip_output,
         start_batch=start_batch,
         extract_dt=extract_dt,
-        dry_run=dry_run,
     )
 
 


### PR DESCRIPTION
Sorry, somehow this survived and wasn't noticed by the linting. Trivial bug.


I suppose it would have been caught by a full integration test 🙃.