### PR TITLE
Allow pinning to omop es commit or get latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker compose build omop-cascade
 
 ## Version Pinning
 
-The `OMOP_ES_BRANCH` environment variable controls which version of `omop_es` to use. It accepts:
+The `OMOP_ES_VERSION` environment variable controls which version of `omop_es` to use. It accepts:
 
 - **Branch name** (e.g., `master`, `feature/xyz`) - Always pulls the latest commit from that branch
 - **Commit SHA** (e.g., `a1b2c3d4` or full SHA) - Pins to a specific commit (no automatic updates)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This repository provides infrastructure tools to run
 [`omop_es`](https://github.com/uclh-criu/omop_es) and
-[`omop-cascade`](https://github.com/uclh-criu/omop-cascade) in
-containerised environments on the GAE.
+[`omop-cascade`](https://github.com/uclh-criu/omop-cascade) in containerised environments on the
+GAE.
 
 In addition, the [`prefect/` directory](prefect/README.md) provides data workflow orchestration with
-[Prefect](https://docs.prefect.io/v3/get-started/index) to allow automatic scheduling of `omop_es` runs.
+[Prefect](https://docs.prefect.io/v3/get-started/index) to allow automatic scheduling of `omop_es`
+runs.
 
 ## Building the images
 
@@ -23,6 +24,18 @@ docker compose build omop_es
 ```shell
 docker compose build omop-cascade
 ```
+
+## Version Pinning
+
+The `OMOP_ES_BRANCH` environment variable controls which version of `omop_es` to use. It accepts:
+
+- **Branch name** (e.g., `master`, `feature/xyz`) - Always pulls the latest commit from that branch
+- **Commit SHA** (e.g., `a1b2c3d4` or full SHA) - Pins to a specific commit (no automatic updates)
+- **Tag name** (e.g., `v1.0.0`) - Pins to a specific release (no automatic updates)
+
+When using a branch name, the container will `git pull` to get the latest code on each run. When
+using a commit SHA or tag, the container will checkout that specific version without pulling
+updates.
 
 ## Running the containers for local development
 
@@ -58,12 +71,13 @@ docker compose -f docker-compose.prod.yml --project-name <PROJECT-NAME> run --bu
 ## Access to private GitHub repos from GAE
 
 To be able to clone GitHub repos on a GAE, create a new
-[fine-grained personal access token](https://github.com/settings/personal-access-tokens),
-make sure the "Resource owner" is set to `uclh-criu` and then select the repositories you want to access.
-Submit the request to generate the token and then make sure to copy the token to a safe place as it will not be shown again!
+[fine-grained personal access token](https://github.com/settings/personal-access-tokens), make sure
+the "Resource owner" is set to `uclh-criu` and then select the repositories you want to access.
+Submit the request to generate the token and then make sure to copy the token to a safe place as it
+will not be shown again!
 
-First store your PAT in a file on the GAE in the path `~/.pat.txt`, then
-configure `git` to use the token by running the following command:
+First store your PAT in a file on the GAE in the path `~/.pat.txt`, then configure `git` to use the
+token by running the following command:
 
 ```shell
 git config --global credential.helper 'store --file ~/.pat.txt'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     environment:
       <<: *proxy-common
       ENVIRONMENT: ${ENVIRONMENT:-dev}
-      OMOP_ES_BRANCH: ${OMOP_ES_BRANCH:-master}
+      OMOP_ES_VERSION: ${OMOP_ES_VERSION:-master}
       RENV_PATHS_CACHE: ${RENV_PATHS_CACHE_CONTAINER}
       SETTINGS_ID: "${SETTINGS_ID}"
       BATCHED: "${BATCHED}"

--- a/docker/omop_es.sh
+++ b/docker/omop_es.sh
@@ -39,17 +39,17 @@ cd $OMOP_ES_DIR
 # Fetch latest refs from remote to ensure we can checkout any branch/tag/commit
 git fetch --all --tags --quiet
 
-# Determine if OMOP_ES_BRANCH is a commit SHA, tag, or branch
+# Determine if OMOP_ES_VERSION is a commit SHA, tag, or branch
 # Check if it's a branch by querying the remote
-if git ls-remote --heads origin "${OMOP_ES_BRANCH}" | grep -q .; then
-	echo "Checking out latest from branch: ${OMOP_ES_BRANCH}"
-	git checkout "${OMOP_ES_BRANCH}"
-	git pull origin "${OMOP_ES_BRANCH}"
+if git ls-remote --heads origin "${OMOP_ES_VERSION}" | grep -q .; then
+	echo "Checking out latest from branch: ${OMOP_ES_VERSION}"
+	git checkout "${OMOP_ES_VERSION}"
+	git pull origin "${OMOP_ES_VERSION}"
 	echo "Running omop_es from commit: $(git rev-parse --short HEAD)"
 else
 	# It's either a commit SHA or a tag - treat as pinned version
-	echo "Checking out pinned version: ${OMOP_ES_BRANCH}"
-	git checkout "${OMOP_ES_BRANCH}"
+	echo "Checking out pinned version: ${OMOP_ES_VERSION}"
+	git checkout "${OMOP_ES_VERSION}"
 	echo "Running omop_es from pinned commit: $(git rev-parse --short HEAD)"
 fi
 

--- a/docker/omop_es.sh
+++ b/docker/omop_es.sh
@@ -40,15 +40,17 @@ cd $OMOP_ES_DIR
 git fetch --all --tags --quiet
 
 # Determine if OMOP_ES_BRANCH is a commit SHA, tag, or branch
-if git rev-parse --verify "${OMOP_ES_BRANCH}^{commit}" >/dev/null 2>&1; then
-	echo "Checking out pinned version: ${OMOP_ES_BRANCH}"
-	git checkout "${OMOP_ES_BRANCH}"
-	echo "Running omop_es from pinned commit: $(git rev-parse --short HEAD)"
-else
+# Check if it's a branch by querying the remote
+if git ls-remote --heads origin "${OMOP_ES_BRANCH}" | grep -q .; then
 	echo "Checking out latest from branch: ${OMOP_ES_BRANCH}"
 	git checkout "${OMOP_ES_BRANCH}"
 	git pull origin "${OMOP_ES_BRANCH}"
 	echo "Running omop_es from commit: $(git rev-parse --short HEAD)"
+else
+	# It's either a commit SHA or a tag - treat as pinned version
+	echo "Checking out pinned version: ${OMOP_ES_BRANCH}"
+	git checkout "${OMOP_ES_BRANCH}"
+	echo "Running omop_es from pinned commit: $(git rev-parse --short HEAD)"
 fi
 
 # Run the batched process if specified, otherwise run the simple process

--- a/prefect/Makefile
+++ b/prefect/Makefile
@@ -23,10 +23,10 @@ clean:   ## Stop all Prefect services, take the server down, and reset the datab
 	$(MAKE) reset-prefect-database
 	rm -rf /tmp/runner_storage
 
-deploy-all:  ## Deploy all Prefect flows
+deploy-all: uv-exists ## Deploy all Prefect flows
 	$(UVRUN) prefect --no-prompt deploy --all
 
-deploy: start-pool ## Deploy a single Prefect flow (interactive selection) and start a worker
+deploy: uv-exists ## Deploy a single Prefect flow (interactive selection) and start a worker
 	$(UVRUN) prefect deploy
 
 start-worker: start-pool ## Start a Prefect worker of type 'process'
@@ -48,7 +48,7 @@ reset-prefect-database: uv-exists ## Reset the Prefect database
 	$(UVRUN) prefect server database reset -y
 
 test: uv-exists ## Run tests of our Prefect functionality
-	$(UVRUN) pytest . --log-cli-level=INFO -s
+	$(UVRUN) pytest . -s
 
 uv-exists: ## Check if uv is available
 	$(call assert_command_exists, uv, "Please install uv: https://docs.astral.sh/uv/getting-started/installation/")

--- a/prefect/prefect.yaml
+++ b/prefect/prefect.yaml
@@ -38,11 +38,11 @@ deployments:
   - name: omop_es-dev
     version:
     tags: [dev]
-    description:
+    description: Development deployment - always pulls latest from master branch
     entrypoint: run_omop_es.py:run_omop_es
     schedules: null
     parameters:
-      omop_es_branch: master
+      omop_es_branch: master  # Branch name - will always pull latest
       settings_id: mock_project_settings
     work_pool:
       name: omop_es-worker
@@ -54,9 +54,15 @@ deployments:
   - name: omop_es-prod
     version:
     tags: [prod]
-    description:
+    description: Production deployment - configure omop_es_branch parameter when deploying
     entrypoint: run_omop_es.py:run_omop_es
     schedules: null
+    parameters:
+      # omop_es_branch can be:
+      # - Branch name (e.g., "master") - always pulls latest
+      # - Commit SHA (e.g., "a1b2c3d4") - pins to specific commit
+      # - Tag name (e.g., "v1.0.0") - pins to release
+      omop_es_branch: master
     work_pool:
       name: omop_es-worker
       work_queue_name: default

--- a/prefect/prefect.yaml
+++ b/prefect/prefect.yaml
@@ -42,7 +42,7 @@ deployments:
     entrypoint: run_omop_es.py:run_omop_es
     schedules: null
     parameters:
-      omop_es_branch: master  # Branch name - will always pull latest
+      omop_es_version: master  # Branch name - will always pull latest
       settings_id: mock_project_settings
     work_pool:
       name: omop_es-worker
@@ -54,15 +54,15 @@ deployments:
   - name: omop_es-prod
     version:
     tags: [prod]
-    description: Production deployment - configure omop_es_branch parameter when deploying
+    description: Production deployment - configure omop_es_version parameter when deploying
     entrypoint: run_omop_es.py:run_omop_es
     schedules: null
     parameters:
-      # omop_es_branch can be:
+      # omop_es_version can be:
       # - Branch name (e.g., "master") - always pulls latest
       # - Commit SHA (e.g., "a1b2c3d4") - pins to specific commit
       # - Tag name (e.g., "v1.0.0") - pins to release
-      omop_es_branch: master
+      omop_es_version: master
     work_pool:
       name: omop_es-worker
       work_queue_name: default

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -54,11 +54,21 @@ def run_omop_es(
     output_directory: str = "",
     zip_output: bool = False,
 ) -> None:
-    build_args = ["--build-arg", f"OMOP_ES_BRANCH={omop_es_branch}"]
-    build_docker(ROOT_PATH, project_name=settings_id, build_args=build_args)
+    """Run omop_es data extraction workflow.
+
+    Args:
+        settings_id: Project settings identifier
+        omop_es_branch: Git ref to use - can be a branch name (pulls latest),
+                       commit SHA (pins to specific version), or tag name (pins to release)
+        batched: Whether to run in batched mode
+        output_directory: Custom output directory path
+        zip_output: Whether to compress output
+    """
+    build_docker(ROOT_PATH, project_name=settings_id)
     run_omop_es_docker(
         working_dir=ROOT_PATH,
         settings_id=settings_id,
+        omop_es_branch=omop_es_branch,
         batched=batched,
         output_directory=output_directory,
         zip_output=zip_output,
@@ -83,7 +93,6 @@ def build_docker(
         "build",
         "omop_es",
     ]
-    args += build_args
     run_subprocess(working_dir, args)
 
 
@@ -91,12 +100,14 @@ def build_docker(
 def run_omop_es_docker(
     working_dir: Path,
     settings_id: str,
+    omop_es_branch: str,
     batched: bool,
     output_directory: str,
     zip_output: bool,
 ) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["SETTINGS_ID"] = settings_id
+    env["OMOP_ES_BRANCH"] = omop_es_branch
     env["BATCHED"] = str(batched)
     env["OUTPUT_DIRECTORY"] = str(output_directory)
     env["ZIP_OUTPUT"] = str(zip_output)
@@ -109,6 +120,8 @@ def run_omop_es_docker(
         "run",
         "--env",
         "SETTINGS_ID",
+        "--env",
+        "OMOP_ES_BRANCH",
         "--env",
         "BATCHED",
         "--env",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -49,7 +49,7 @@ def use_prod_if(condition: bool):
 @flow(flow_run_name=name_with_timestamp, log_prints=True)
 def run_omop_es(
     settings_id: str,
-    omop_es_branch: str = "master",
+    omop_es_version: str = "master",
     batched: bool = False,
     output_directory: str = "",
     zip_output: bool = False,
@@ -58,7 +58,7 @@ def run_omop_es(
 
     Args:
         settings_id: Project settings identifier
-        omop_es_branch: Git ref to use - can be a branch name (pulls latest),
+        omop_es_version: Git ref to use - can be a branch name (pulls latest),
                        commit SHA (pins to specific version), or tag name (pins to release)
         batched: Whether to run in batched mode
         output_directory: Custom output directory path
@@ -68,7 +68,7 @@ def run_omop_es(
     run_omop_es_docker(
         working_dir=ROOT_PATH,
         settings_id=settings_id,
-        omop_es_branch=omop_es_branch,
+        omop_es_version=omop_es_version,
         batched=batched,
         output_directory=output_directory,
         zip_output=zip_output,
@@ -100,14 +100,14 @@ def build_docker(
 def run_omop_es_docker(
     working_dir: Path,
     settings_id: str,
-    omop_es_branch: str,
+    omop_es_version: str,
     batched: bool,
     output_directory: str,
     zip_output: bool,
 ) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["SETTINGS_ID"] = settings_id
-    env["OMOP_ES_BRANCH"] = omop_es_branch
+    env["OMOP_ES_VERSION"] = omop_es_version
     env["BATCHED"] = str(batched)
     env["OUTPUT_DIRECTORY"] = str(output_directory)
     env["ZIP_OUTPUT"] = str(zip_output)
@@ -121,7 +121,7 @@ def run_omop_es_docker(
         "--env",
         "SETTINGS_ID",
         "--env",
-        "OMOP_ES_BRANCH",
+        "OMOP_ES_VERSION",
         "--env",
         "BATCHED",
         "--env",

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -92,7 +92,7 @@ def test_run_omop_es_docker_sets_env_correctly(mocker):
     with disable_run_logger():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
-            settings_id="mock_project_settings",
+            settings_id="test",
             omop_es_branch="master",
             batched=False,
             output_directory="",
@@ -101,7 +101,7 @@ def test_run_omop_es_docker_sets_env_correctly(mocker):
 
     # String values of the arguments we passed into the function 👆
     expected_env_values = {
-        "SETTINGS_ID": "mock_project_settings",
+        "SETTINGS_ID": "test",
         "BATCHED": "False",
         "OUTPUT_DIRECTORY": "",
         "ZIP_OUTPUT": "False",
@@ -118,14 +118,14 @@ def test_run_omop_es_docker_can_run_batched():
     with disable_run_logger():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
-            settings_id="mock_project_settings",
+            settings_id="test",
             omop_es_branch="master",
             batched=True,
             output_directory="foo",
             zip_output=True,
         )
 
-    expected_command = "Rscript ./main/batched.R --settings_id mock_project_settings --output_directory foo --zip_output"
+    expected_command = "Rscript ./main/batched.R --settings_id test --output_directory foo --zip_output"
 
     ## Check that expected_command is the last line of result.stdout
     assert expected_command == result.stdout.strip().split("\n")[-1], (
@@ -140,7 +140,7 @@ def test_version_pinning_with_branch_pulls_latest():
     with disable_run_logger():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
-            settings_id="mock_project_settings",
+            settings_id="test",
             omop_es_branch="master",
             batched=False,
             output_directory="",
@@ -163,7 +163,7 @@ def test_version_pinning_with_commit_sha():
     with disable_run_logger():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
-            settings_id="mock_project_settings",
+            settings_id="test",
             omop_es_branch=test_sha,
             batched=False,
             output_directory="",
@@ -173,4 +173,26 @@ def test_version_pinning_with_commit_sha():
     output = result.stdout.strip().split("\n")
     assert f"Checking out pinned version: {test_sha}" in output, (
         f"Expected version checkout message in stdout output: {output}"
+    )
+
+
+def test_version_pinning_fails_with_invalid_sha():
+    """Test that using an invalid commit SHA results in an error."""
+    os.environ["DEBUG"] = "true"
+
+    test_sha = "invalid_sha"
+
+    # with pytest.raises():
+    with disable_run_logger():
+        result = run_omop_es.run_omop_es_docker.fn(
+            working_dir=run_omop_es.ROOT_PATH,
+            settings_id="test",
+            omop_es_branch=test_sha,
+            batched=False,
+            output_directory="",
+            zip_output=False,
+        )
+
+    assert "Invalid commit SHA" in result.stderr, (
+        f"Expected error message in stderr output: {result.stderr}"
     )

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -107,7 +107,7 @@ def test_run_omop_es_docker_sets_env_correctly(mocker):
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
             settings_id=PROJECT_NAME,
-            omop_es_branch="master",
+            omop_es_version="master",
             batched=False,
             output_directory="",
             zip_output=False,
@@ -133,7 +133,7 @@ def test_run_omop_es_docker_can_run_batched():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
             settings_id=PROJECT_NAME,
-            omop_es_branch="master",
+            omop_es_version="master",
             batched=True,
             output_directory="foo",
             zip_output=True,
@@ -155,7 +155,7 @@ def test_version_pinning_with_branch_pulls_latest():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
             settings_id=PROJECT_NAME,
-            omop_es_branch="master",
+            omop_es_version="master",
             batched=False,
             output_directory="",
             zip_output=False,
@@ -178,7 +178,7 @@ def test_version_pinning_with_commit_sha():
         result = run_omop_es.run_omop_es_docker.fn(
             working_dir=run_omop_es.ROOT_PATH,
             settings_id=PROJECT_NAME,
-            omop_es_branch=test_sha,
+            omop_es_version=test_sha,
             batched=False,
             output_directory="",
             zip_output=False,
@@ -201,7 +201,7 @@ def test_version_pinning_fails_with_invalid_sha():
             run_omop_es.run_omop_es_docker.fn(
                 working_dir=run_omop_es.ROOT_PATH,
                 settings_id=PROJECT_NAME,
-                omop_es_branch=test_sha,
+                omop_es_version=test_sha,
                 batched=False,
                 output_directory="",
                 zip_output=False,

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -14,7 +14,9 @@
 ################################################################################
 
 import os
+import subprocess
 
+import pytest
 from freezegun import freeze_time
 from prefect.logging import disable_run_logger
 
@@ -182,17 +184,13 @@ def test_version_pinning_fails_with_invalid_sha():
 
     test_sha = "invalid_sha"
 
-    # with pytest.raises():
-    with disable_run_logger():
-        result = run_omop_es.run_omop_es_docker.fn(
-            working_dir=run_omop_es.ROOT_PATH,
-            settings_id="test",
-            omop_es_branch=test_sha,
-            batched=False,
-            output_directory="",
-            zip_output=False,
-        )
-
-    assert "Invalid commit SHA" in result.stderr, (
-        f"Expected error message in stderr output: {result.stderr}"
-    )
+    with pytest.raises(subprocess.CalledProcessError):
+        with disable_run_logger():
+            run_omop_es.run_omop_es_docker.fn(
+                working_dir=run_omop_es.ROOT_PATH,
+                settings_id="test",
+                omop_es_branch=test_sha,
+                batched=False,
+                output_directory="",
+                zip_output=False,
+            )

--- a/template.env
+++ b/template.env
@@ -11,6 +11,11 @@ DOCKER_USER_GID=993
 # Create token for omop_es and omop-cascade repos:
 # https://github.com/settings/tokens/new
 GITHUB_PAT=
+
+# OMOP_ES_BRANCH can be:
+# - A branch name (e.g., "master", "feature/xyz") - always pulls latest from that branch
+# - A commit SHA (e.g., "a1b2c3d4") - pins to that specific commit (no automatic updates)
+# - A tag (e.g., "v1.0.0") - pins to that specific release (no automatic updates)
 OMOP_ES_BRANCH=master
 
 RENV_PATHS_CACHE_HOST=./.cache/renv

--- a/template.env
+++ b/template.env
@@ -12,11 +12,11 @@ DOCKER_USER_GID=993
 # https://github.com/settings/tokens/new
 GITHUB_PAT=
 
-# OMOP_ES_BRANCH can be:
+# OMOP_ES_VERSION can be:
 # - A branch name (e.g., "master", "feature/xyz") - always pulls latest from that branch
 # - A commit SHA (e.g., "a1b2c3d4") - pins to that specific commit (no automatic updates)
 # - A tag (e.g., "v1.0.0") - pins to that specific release (no automatic updates)
-OMOP_ES_BRANCH=master
+OMOP_ES_VERSION=master
 
 RENV_PATHS_CACHE_HOST=./.cache/renv
 RENV_PATHS_CACHE_CONTAINER=/renv/cache


### PR DESCRIPTION
The `omop_es.sh` entrypoint script now checks if `OMOP_ES_VERSION` (previously `OMOP_ES_BRANCH`) is a branch name, commit sha or version tag and

- if it's branch name, always pulls the latest commit from that branch
- if not, pins the `omop_es` repo to the provided sha or tag

Closes DEP-30 (#28)