### PR TITLE
Use fixed output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ In addition, the [`prefect/` directory](prefect/) provides data workflow orchest
 [Prefect](https://docs.prefect.io/v3/get-started/index) to allow automatic scheduling of `omop_es`
 runs.
 
+## Requirements
+
+This repository requires [`uv`](https://docs.astral.sh/uv/getting-started/installation/) to be installed.
+
+For GAE users, please follow these [instructions](https://uclh.slab.com/posts/shared-virtual-python-environments-with-uv-u7pa2fv4#h8mzl-per-person-setup-tasks).
+
 ## Deploying the Prefect infrastructure
 
 <!--prettier-ignore-->

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -50,7 +50,7 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{name_with_timestamp()}", log_prints=True)
+@flow(flow_run_name="{"+"settings_id"+"}_"+datetime.datetime.now(datetime.timezone.utc):%Y%m%d_%H%M%S, log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -55,6 +55,7 @@ def run_omop_es(
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
+    date: str = datetime.datetime,
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -49,7 +49,7 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{date:%A}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{date:%Y%m%d%H%M%S}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -50,12 +50,11 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name=name_with_timestamp, log_prints=True)
+@flow(flow_run_name="{settings_id}-{name_with_timestamp}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",
     batched: bool = False,
-    output_directory: str = "",
     zip_output: bool = False,
 ) -> None:
     """Run omop_es data extraction workflow.
@@ -64,7 +63,6 @@ def run_omop_es(
         settings_id: Project settings identifier
         omop_es_version: Git ref to use - can be a branch name, commit SHA, or tag name
         batched: Whether to run in batched mode
-        output_directory: Custom output directory path
         zip_output: Whether to compress output
     """
     pinned_version = pin_omop_es_version(omop_es_version)
@@ -74,7 +72,7 @@ def run_omop_es(
         settings_id=settings_id,
         omop_es_version=pinned_version,
         batched=batched,
-        output_directory=output_directory,
+        output_directory=runtime.flow_run.name,
         zip_output=zip_output,
     )
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -30,10 +30,9 @@ IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 
 logger = logging.get_logger()
 
-def name_with_timestamp() -> str:
-    """Generate a name for the flow run with a timestamp."""
+def get_flow_datetime() -> str:
+    """Generate a datetime (YYYYmmdd_HHMMSS) for the flow run name."""
     now = datetime.datetime.now(datetime.timezone.utc)
-    # return f"{DEPLOYMENT_NAME}_{now.isoformat()}"
     return f"{now:%Y%m%d_%H%M%S}"
 
 
@@ -50,13 +49,13 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{"+"settings_id"+"}_"+name_with_timestamp(), log_prints=True)
+# use string concatenation to avoid processing of curly brackets
+@flow(flow_run_name="{"+"settings_id"+"}-"+get_flow_datetime(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    # extract_dt: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -30,6 +30,7 @@ IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 
 logger = logging.get_logger()
 
+EXTRACT_DATETIME = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 def name_with_timestamp() -> str:
     """Generate a name for the flow run with a timestamp."""
@@ -50,7 +51,7 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{name_with_timestamp}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{EXTRACT_DATETIME}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -55,7 +55,7 @@ def run_omop_es(
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    date: datetime.datetime,
+    date: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -55,7 +55,7 @@ def run_omop_es(
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    extract_datetime: str = datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    extract_datetime: str = name_with_timestamp(),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -50,7 +50,7 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{name_with_timestamp}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{name_with_timestamp()}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -50,7 +50,7 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{"+"settings_id"+"}_"+datetime.datetime.now(datetime.timezone.utc):%Y%m%d_%H%M%S, log_prints=True)
+@flow(flow_run_name="{"+"settings_id"+"}_"+name_with_timestamp(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -33,7 +33,8 @@ logger = logging.get_logger()
 def name_with_timestamp() -> str:
     """Generate a name for the flow run with a timestamp."""
     now = datetime.datetime.now(datetime.timezone.utc)
-    return f"{DEPLOYMENT_NAME}_{now.isoformat()}"
+    # return f"{DEPLOYMENT_NAME}_{now.isoformat()}"
+    return f"{now:%Y%m%d_%H%M%S}"
 
 
 def dry_run_if(condition: bool):
@@ -49,13 +50,13 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{date:%Y%m%d%H%M%S}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{name_with_timestamp}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    date: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
+    # extract_dt: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -30,8 +30,6 @@ IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 
 logger = logging.get_logger()
 
-EXTRACT_DATETIME = datetime.datetime.now(datetime.timezone.utc).isoformat()
-
 def name_with_timestamp() -> str:
     """Generate a name for the flow run with a timestamp."""
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -51,12 +49,13 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{EXTRACT_DATETIME}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{extract_datetime}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
+    extract_datetime: str = datetime.datetime.now(datetime.timezone.utc).isoformat(),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -25,7 +25,6 @@ from prefect import flow, logging, runtime, task
 from run_subprocess import run_subprocess
 
 ROOT_PATH = Path(__file__).parents[1]
-DEPLOYMENT_NAME = str(runtime.deployment.name).lower()
 IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 
 logger = logging.get_logger()
@@ -51,7 +50,7 @@ def use_prod_if(condition: bool):
 
 
 # use string concatenation to avoid processing of curly brackets
-@flow(flow_run_name="{" + "settings_id" + "}-" + get_flow_datetime(), log_prints=True)
+@flow(flow_run_name="{settings_id}-" + get_flow_datetime(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -49,13 +49,12 @@ def use_prod_if(condition: bool):
         yield "docker-compose.prod.yml"
 
 
-@flow(flow_run_name="{settings_id}-{extract_datetime}", log_prints=True)
+@flow(flow_run_name="{settings_id}-{date:%A}", log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    extract_datetime: str = name_with_timestamp(),
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -50,7 +50,7 @@ def use_prod_if(condition: bool):
 
 
 # use string concatenation to avoid processing of curly brackets
-@flow(flow_run_name="{"+"settings_id"+"}-"+get_flow_datetime(), log_prints=True)
+@flow(flow_run_name="{" + "settings_id" + "}-" + get_flow_datetime(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -55,7 +55,7 @@ def run_omop_es(
     omop_es_version: str = "master",
     batched: bool = False,
     zip_output: bool = False,
-    date: str = datetime.datetime,
+    date: datetime.datetime,
 ) -> None:
     """Run omop_es data extraction workflow.
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -30,6 +30,7 @@ IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 
 logger = logging.get_logger()
 
+
 def get_flow_datetime() -> str:
     """Generate a datetime (YYYYmmdd_HHMMSS) for the flow run name."""
     now = datetime.datetime.now(datetime.timezone.utc)

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -39,8 +39,8 @@ def get_flow_id() -> str:
     """Retrieve the flow run ID from parent if exists otherwise newly created."""
     parent_id = runtime.flow_run.parent_flow_run_id
     if not parent_id:
-        return runtime.flow_run.id
-    return parent_id
+        return f"{runtime.flow_run.id}"
+    return f"{parent_id}"
 
 def dry_run_if(condition: bool):
     """Optionally yield the dry-run flag for docker compose commands."""

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -30,12 +30,6 @@ IS_PROD = os.environ.get("ENVIRONMENT", "dev") == "prod"
 logger = logging.get_logger()
 
 
-def get_flow_datetime() -> str:
-    """Generate a datetime (YYYYmmdd_HHMMSS) for the flow run name."""
-    now = datetime.datetime.now(datetime.timezone.utc)
-    return f"{now:%Y%m%d_%H%M%S}"
-
-
 def get_flow_id() -> str:
     """Retrieve the flow run ID."""
     return f"{runtime.flow_run.id}"

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -37,10 +37,11 @@ def get_flow_datetime() -> str:
 
 def get_flow_id() -> str:
     """Retrieve the flow run ID from parent if exists otherwise newly created."""
-    parent_id = runtime.flow_run.parent_flow_run_id
-    if not parent_id:
-        return f"{runtime.flow_run.id}"
-    return f"{parent_id}"
+    # parent_id = runtime.flow_run.parent_flow_run_id
+    # if not parent_id:
+    #     return f"{runtime.flow_run.id}"
+    # return f"{parent_id}"
+    return f"{runtime.flow_run.id}"
 
 def dry_run_if(condition: bool):
     """Optionally yield the dry-run flag for docker compose commands."""
@@ -56,7 +57,7 @@ def use_prod_if(condition: bool):
 
 
 # use string concatenation to avoid processing of curly brackets
-@flow(flow_run_name="{settings_id}-" + get_flow_id(), log_prints=True)
+@flow(flow_run_name="{settings_id}." + get_flow_id(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -35,13 +35,11 @@ def get_flow_datetime() -> str:
     now = datetime.datetime.now(datetime.timezone.utc)
     return f"{now:%Y%m%d_%H%M%S}"
 
+
 def get_flow_id() -> str:
-    """Retrieve the flow run ID from parent if exists otherwise newly created."""
-    # parent_id = runtime.flow_run.parent_flow_run_id
-    # if not parent_id:
-    #     return f"{runtime.flow_run.id}"
-    # return f"{parent_id}"
+    """Retrieve the flow run ID."""
     return f"{runtime.flow_run.id}"
+
 
 def dry_run_if(condition: bool):
     """Optionally yield the dry-run flag for docker compose commands."""

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -35,6 +35,12 @@ def get_flow_datetime() -> str:
     now = datetime.datetime.now(datetime.timezone.utc)
     return f"{now:%Y%m%d_%H%M%S}"
 
+def get_flow_id() -> str:
+    """Retrieve the flow run ID from parent if exists otherwise newly created."""
+    parent_id = runtime.flow_run.parent_flow_run_id
+    if not parent_id:
+        return runtime.flow_run.id
+    return parent_id
 
 def dry_run_if(condition: bool):
     """Optionally yield the dry-run flag for docker compose commands."""
@@ -50,7 +56,7 @@ def use_prod_if(condition: bool):
 
 
 # use string concatenation to avoid processing of curly brackets
-@flow(flow_run_name="{settings_id}-" + get_flow_datetime(), log_prints=True)
+@flow(flow_run_name="{settings_id}-" + get_flow_id(), log_prints=True)
 def run_omop_es(
     settings_id: str,
     omop_es_version: str = "master",

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 ################################################################################
 
-import datetime
 import os
 import re
 import subprocess

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -43,10 +43,10 @@ def rebuild_test_docker():
 
 
 @freeze_time("2025-01-01")
-def test_name_with_timestamp():
+def test_get_flow_datetime():
     # The prefect deployment name is set to 'None' (because we're not in a prefect deployment)
     # we intercept this and set it to lowercase because docker is picky about project names.
-    assert run_omop_es.name_with_timestamp() == "none_2025-01-01T00:00:00+00:00"
+    assert run_omop_es.get_flow_datetime() == "20250101_000000"
 
 
 def test_star_dry_run_if():

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -44,7 +44,7 @@ def rebuild_test_docker():
 
 @freeze_time("2025-01-01")
 def test_get_flow_datetime():
-    # Test that *get_flow_datetime returns the correct formatted datetime
+    # Test that get_flow_datetime returns the correct formatted datetime
     assert run_omop_es.get_flow_datetime() == "20250101_000000"
 
 

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -44,8 +44,7 @@ def rebuild_test_docker():
 
 @freeze_time("2025-01-01")
 def test_get_flow_datetime():
-    # The prefect deployment name is set to 'None' (because we're not in a prefect deployment)
-    # we intercept this and set it to lowercase because docker is picky about project names.
+    # Test that *get_flow_datetime returns the correct formatted datetime
     assert run_omop_es.get_flow_datetime() == "20250101_000000"
 
 

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -42,12 +42,6 @@ def rebuild_test_docker():
             pytest.fail(f"Failed to build docker image: {e}")
 
 
-@freeze_time("2025-01-01")
-def test_get_flow_datetime():
-    # Test that get_flow_datetime returns the correct formatted datetime
-    assert run_omop_es.get_flow_datetime() == "20250101_000000"
-
-
 def test_star_dry_run_if():
     # Test that *dry_run_if expands as we expect
     command_with = ["docker", "compose", *run_omop_es.dry_run_if(True), "do-thing"]

--- a/prefect/test_run_omop_es.py
+++ b/prefect/test_run_omop_es.py
@@ -17,7 +17,6 @@ import os
 from subprocess import CalledProcessError
 
 import pytest
-from freezegun import freeze_time
 from prefect.logging import disable_run_logger
 
 import run_omop_es


### PR DESCRIPTION
This PR remove the need of specifying the output directory to restart an OMOP_ES batched extract.

It uses the OMOP_ES `settings_id` environment variable and a datetime (to seconds) to generate an unique name for each extract. This name is automatically passed as 
argument to the task.

It also updates the README with instructions on how to setup `uv`.

Closes DEP-63