### PR TITLE
Replace GITHUB_PAT with SSH deploy keys in Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,11 +40,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.OMOP_ES_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/id_ed25519
       - name: Build the Docker image
         env:
-          GITHUB_PAT: ${{ secrets.OMOP_ES_GITHUB_PAT }}
+          DOCKER_BUILDKIT: 1
         run: |
           cp template.env .env
           cp omop_es/template.env omop_es/.env
           cp omop-cascade/template.env omop-cascade/.env
-          docker compose build ${{ matrix.image }} --build-arg GITHUB_PAT=${GITHUB_PAT}
+          docker compose build ${{ matrix.image }}

--- a/.github/workflows/prefect-flow-tests.yml
+++ b/.github/workflows/prefect-flow-tests.yml
@@ -60,7 +60,5 @@ jobs:
 
       - name: Run pytest
         working-directory: ./prefect
-        env:
-          GITHUB_PAT: ${{ secrets.OMOP_ES_GITHUB_PAT }}
         run: |
           uv run pytest . -s

--- a/README.md
+++ b/README.md
@@ -207,20 +207,20 @@ This will have to be repeated whenever the `/tmp/runner_storage` gets removed an
 Use `docker compose build` to build all images, or specify the image to build.
 
 **Note:** Building Docker images requires SSH authentication. Ensure your SSH agent is running and
-has the deploy key loaded before building. See
+has the deploy key loaded before building. BuildKit must be enabled for SSH forwarding. See
 [Access to private GitHub repos with SSH Deploy Keys](#access-to-private-github-repos-with-ssh-deploy-keys)
 for setup instructions.
 
 ### `omop_es`
 
 ```shell
-docker compose build omop_es
+DOCKER_BUILDKIT=1 docker compose build omop_es
 ```
 
 ### `omop-cascade`
 
 ```shell
-docker compose build omop-cascade
+DOCKER_BUILDKIT=1 docker compose build omop-cascade
 ```
 
 ## Version Pinning

--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ This will have to be repeated whenever the `/tmp/runner_storage` gets removed an
 
 Use `docker compose build` to build all images, or specify the image to build.
 
+**Note:** Building Docker images requires SSH authentication. Ensure your SSH agent is running and
+has the deploy key loaded before building. See
+[Access to private GitHub repos with SSH Deploy Keys](#access-to-private-github-repos-with-ssh-deploy-keys)
+for setup instructions.
+
 ### `omop_es`
 
 ```shell
@@ -257,25 +262,72 @@ docker compose -f docker-compose.prod.yml --project-name <PROJECT-NAME> run --bu
     omop_es
 ```
 
-## Access to private GitHub repos from GAE
+## Access to private GitHub repos with SSH Deploy Keys
 
-To be able to clone GitHub repos on a GAE, create a new
-[fine-grained personal access token](https://github.com/settings/personal-access-tokens), make sure
-the "Resource owner" is set to `uclh-criu` and then select the repositories you want to access.
-Submit the request to generate the token and then make sure to copy the token to a safe place as it
-will not be shown again!
+### Creating Deploy Keys
 
-First store your PAT in a file on the GAE in the path `~/.pat.txt`, then configure `git` to use the
-token by running the following command:
+1. Generate an SSH key pair (if you don't have one):
 
-```shell
-git config --global credential.helper 'store --file ~/.pat.txt'
+   ```bash
+   ssh-keygen -t ed25519 -C "crdm-tools-deploy-key" -f ~/.ssh/crdm_deploy_key
+   ```
+
+2. Add the public key as a deploy key to both repositories:
+   - Go to `https://github.com/uclh-criu/omop_es/settings/keys`
+   - Click "Add deploy key"
+   - Paste contents of `~/.ssh/crdm_deploy_key.pub`
+   - Grant read-only access
+   - Repeat for `https://github.com/uclh-criu/omop-cascade`
+
+### Local Development Setup
+
+For Docker builds to work, ensure your SSH key is loaded:
+
+```bash
+# Start SSH agent
+eval "$(ssh-agent -s)"
+
+# Add your key
+ssh-add ~/.ssh/crdm_deploy_key
+
+# Verify access
+ssh -T git@github.com
+
+# Build with SSH forwarding
+docker compose build omop_es
 ```
 
-This process needs to be repeated for every GAE.
+Docker BuildKit automatically forwards your SSH agent to build containers.
 
-Additionally record the token in the `GITHUB_PAT` environment variable in the `.env` file in this
-repository's root.
+### GAE Setup
+
+On each GAE instance:
+
+1. Copy the private key to the GAE:
+
+   ```bash
+   scp ~/.ssh/crdm_deploy_key user@gae-host:~/.ssh/id_ed25519
+   ```
+
+2. Set proper permissions:
+
+   ```bash
+   chmod 600 ~/.ssh/id_ed25519
+   ```
+
+3. Add to SSH agent:
+
+   ```bash
+   eval "$(ssh-agent -s)"
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+4. For persistent agent, add to `~/.bashrc` or use a systemd service.
+
+### GitHub Actions Setup
+
+The deploy key private key is stored as a GitHub Actions secret (`OMOP_ES_DEPLOY_KEY`). This is
+automatically configured in CI/CD workflows.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ In addition, the [`prefect/` directory](prefect/) provides data workflow orchest
 [Prefect](https://docs.prefect.io/v3/get-started/index) to allow automatic scheduling of `omop_es`
 runs.
 
+## Access to private GitHub repos with SSH Deploy Keys
+
+See [docs/ssh-deploy-keys.md](docs/ssh-deploy-keys.md).
+
 ## Deploying the Prefect infrastructure
 
 <!--prettier-ignore-->
@@ -261,73 +265,6 @@ docker compose -f docker-compose.prod.yml --project-name <PROJECT-NAME> run --bu
     --env ... \
     omop_es
 ```
-
-## Access to private GitHub repos with SSH Deploy Keys
-
-### Creating Deploy Keys
-
-1. Generate an SSH key pair (if you don't have one):
-
-   ```bash
-   ssh-keygen -t ed25519 -C "crdm-tools-deploy-key" -f ~/.ssh/crdm_deploy_key
-   ```
-
-2. Add the public key as a deploy key to both repositories:
-   - Go to `https://github.com/uclh-criu/omop_es/settings/keys`
-   - Click "Add deploy key"
-   - Paste contents of `~/.ssh/crdm_deploy_key.pub`
-   - Grant read-only access
-   - Repeat for `https://github.com/uclh-criu/omop-cascade`
-
-### Local Development Setup
-
-For Docker builds to work, ensure your SSH key is loaded:
-
-```bash
-# Start SSH agent
-eval "$(ssh-agent -s)"
-
-# Add your key
-ssh-add ~/.ssh/crdm_deploy_key
-
-# Verify access
-ssh -T git@github.com
-
-# Build with SSH forwarding
-docker compose build omop_es
-```
-
-Docker BuildKit automatically forwards your SSH agent to build containers.
-
-### GAE Setup
-
-On each GAE instance:
-
-1. Copy the private key to the GAE:
-
-   ```bash
-   scp ~/.ssh/crdm_deploy_key user@gae-host:~/.ssh/id_ed25519
-   ```
-
-2. Set proper permissions:
-
-   ```bash
-   chmod 600 ~/.ssh/id_ed25519
-   ```
-
-3. Add to SSH agent:
-
-   ```bash
-   eval "$(ssh-agent -s)"
-   ssh-add ~/.ssh/id_ed25519
-   ```
-
-4. For persistent agent, add to `~/.bashrc` or use a systemd service.
-
-### GitHub Actions Setup
-
-The deploy key private key is stored as a GitHub Actions secret (`OMOP_ES_DEPLOY_KEY`). This is
-automatically configured in CI/CD workflows.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,10 +66,14 @@ services:
       BATCHED: "${BATCHED}"
       OUTPUT_DIRECTORY: "${OUTPUT_DIRECTORY}"
       ZIP_OUTPUT: "${ZIP_OUTPUT}"
+      SSH_AUTH_SOCK: /ssh-agent
       TZ: Europe/London
     volumes:
       - "./extract:/app/extract"
       - "${RENV_PATHS_CACHE_HOST}:${RENV_PATHS_CACHE_CONTAINER}"
+      - type: bind
+        source: ${SSH_AUTH_SOCK}
+        target: /ssh-agent
 
   omop-cascade:
     env_file: "./omop-cascade/.env"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,6 @@ x-docker-gid: &docker-gid
 x-build-args-common: &build-args-common
   <<: [*proxy-common, *docker-gid]
 
-x-github-pat: &github-pat
-  GITHUB_PAT: ${GITHUB_PAT}
-
 services:
   prefect_server:
     image: prefecthq/prefect:3-latest
@@ -55,8 +52,10 @@ services:
     build:
       context: "./docker"
       target: omop_es
+      ssh:
+        - default
       args:
-        <<: [*build-args-common, *github-pat]
+        <<: *build-args-common
     platform: linux/amd64
     environment:
       <<: *proxy-common
@@ -77,8 +76,10 @@ services:
     build:
       context: "./docker"
       target: omop-cascade
+      ssh:
+        - default
       args:
-        <<: [*build-args-common, *github-pat]
+        <<: *build-args-common
         OMOP_CASCADE_BRANCH: ${OMOP_CASCADE_BRANCH:-master}
     platform: linux/amd64
     environment:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,11 +92,9 @@ RUN --mount=type=ssh \
 
 WORKDIR /app/omop_es
 
-ARG OMOP_ES_VERSION="master"
 RUN --mount=type=ssh \
     git config --global --add safe.directory /app/omop_es && \
     git fetch --all --tags --quiet && \
-    git checkout ${OMOP_ES_VERSION} && \
     chown -R docker:docker /app/omop_es
 
 USER docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,10 @@ RUN apt-get update && \
     libnode-dev \
     gnupg \
     libudunits2-dev \
-    libgdal-dev && \
+    libgdal-dev \
+    # git and SSH client for runtime operations
+    git \
+    openssh-client && \
     apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
 
 # Enable Microsoft SQLServer
@@ -100,6 +103,12 @@ USER docker
 
 # Final omop_es image
 FROM base AS omop_es
+
+# Configure SSH known_hosts for GitHub (as docker user)
+# Needed for runtime operations
+RUN mkdir -p -m 0700 /home/docker/.ssh && \
+    ssh-keyscan github.com >> /home/docker/.ssh/known_hosts && \
+    chmod 600 /home/docker/.ssh/known_hosts
 
 COPY --from=omop_es-builder --chown=docker:docker --chmod=0755 /app/omop_es /app/omop_es
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# syntax=docker/dockerfile:1
+
 FROM rocker/tidyverse:4.4.3 AS base
 
 ARG DOCKER_USER_GID=1000
@@ -67,18 +69,27 @@ WORKDIR /app
 
 
 # omop_es-builder
-# using multi-stage build so the GitHub PAT is not present in the final image
+# using multi-stage build so SSH keys are not present in the final image
 FROM base AS omop_es-builder
 
-ARG GITHUB_PAT
-RUN test -n "$GITHUB_PAT" || (echo "GITHUB_PAT is required" && exit 1)
+# Install SSH client
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openssh-client && \
+    apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
+USER docker
 
-RUN git clone https://${GITHUB_PAT}@github.com/uclh-criu/omop_es.git ./omop_es
+# Configure SSH known_hosts for GitHub
+RUN mkdir -p -m 0700 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Mount SSH agent socket and clone with SSH
+RUN --mount=type=ssh git clone git@github.com:uclh-criu/omop_es.git ./omop_es
 
 WORKDIR /app/omop_es
 
 ARG OMOP_ES_VERSION="master"
-RUN git fetch --all --tags --quiet && \
+RUN --mount=type=ssh git fetch --all --tags --quiet && \
     git checkout ${OMOP_ES_VERSION}
 
 # Final omop_es image
@@ -103,14 +114,25 @@ CMD ["/app/omop_es.sh"]
 
 # omop-cascade
 # omop-cascade-builder
-# using multi-stage build so the GitHub PAT is not present in the final image
+# using multi-stage build so SSH keys are not present in the final image
 FROM base AS omop-cascade-builder
 
 ARG OMOP_CASCADE_BRANCH
-ARG GITHUB_PAT
 
-RUN git clone -b ${OMOP_CASCADE_BRANCH} \
-    https://${GITHUB_PAT}@github.com/uclh-criu/omop-cascade.git \
+# Install SSH client
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openssh-client && \
+    apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
+USER docker
+
+# Configure SSH known_hosts for GitHub
+RUN mkdir -p -m 0700 ~/.ssh && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Mount SSH agent socket and clone with SSH
+RUN --mount=type=ssh git clone -b ${OMOP_CASCADE_BRANCH} \
+    git@github.com:uclh-criu/omop-cascade.git \
     /app/omop-cascade
 
 # omop-cascade

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,25 +72,31 @@ WORKDIR /app
 # using multi-stage build so SSH keys are not present in the final image
 FROM base AS omop_es-builder
 
-# Install SSH client
+# Install SSH client and configure SSH as root
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends openssh-client && \
     apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
-USER docker
 
 # Configure SSH known_hosts for GitHub
-RUN mkdir -p -m 0700 ~/.ssh && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN mkdir -p -m 0700 /root/.ssh && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts
 
-# Mount SSH agent socket and clone with SSH
-RUN --mount=type=ssh git clone git@github.com:uclh-criu/omop_es.git ./omop_es
+# Mount SSH agent socket and clone with SSH (must run as root for socket access)
+RUN --mount=type=ssh \
+    git clone git@github.com:milanmlft/omop_es.git /app/omop_es && \
+    chown -R docker:docker /app/omop_es
 
 WORKDIR /app/omop_es
 
 ARG OMOP_ES_VERSION="master"
-RUN --mount=type=ssh git fetch --all --tags --quiet && \
-    git checkout ${OMOP_ES_VERSION}
+RUN --mount=type=ssh \
+    git config --global --add safe.directory /app/omop_es && \
+    git fetch --all --tags --quiet && \
+    git checkout ${OMOP_ES_VERSION} && \
+    chown -R docker:docker /app/omop_es
+
+USER docker
 
 # Final omop_es image
 FROM base AS omop_es
@@ -119,21 +125,20 @@ FROM base AS omop-cascade-builder
 
 ARG OMOP_CASCADE_BRANCH
 
-# Install SSH client
+# Install SSH client and configure SSH as root
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends openssh-client && \
     apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
-USER docker
 
 # Configure SSH known_hosts for GitHub
-RUN mkdir -p -m 0700 ~/.ssh && \
-    ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN mkdir -p -m 0700 /root/.ssh && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts
 
-# Mount SSH agent socket and clone with SSH
-RUN --mount=type=ssh git clone -b ${OMOP_CASCADE_BRANCH} \
-    git@github.com:uclh-criu/omop-cascade.git \
-    /app/omop-cascade
+# Mount SSH agent socket and clone with SSH (must run as root for socket access)
+RUN --mount=type=ssh \
+    git clone -b ${OMOP_CASCADE_BRANCH} git@github.com:uclh-criu/omop-cascade.git /app/omop-cascade && \
+    chown -R docker:docker /app/omop-cascade
 
 # omop-cascade
 FROM base AS omop-cascade

--- a/docker/omop_es.sh
+++ b/docker/omop_es.sh
@@ -16,6 +16,20 @@
 
 set -euxo pipefail
 
+# Verify SSH agent is available for git operations
+if [ ! -S "$SSH_AUTH_SOCK" ]; then
+    echo "ERROR: SSH agent socket not found at SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
+    echo "Ensure SSH agent is running and SSH_AUTH_SOCK is correctly mounted."
+    exit 1
+fi
+
+# Test SSH connection to GitHub
+if ! ssh -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
+    echo "ERROR: SSH authentication to GitHub failed."
+    echo "Ensure the SSH deploy key is loaded in the SSH agent."
+    exit 1
+fi
+
 # Helper function to convert to lowercase
 tolower() {
 	echo "$1" | tr '[:upper:]' '[:lower:]'

--- a/docs/ssh-deploy-keys.md
+++ b/docs/ssh-deploy-keys.md
@@ -1,0 +1,66 @@
+## Access to private GitHub repos with SSH Deploy Keys
+
+### Creating Deploy Keys
+
+1. Generate an SSH key pair (if you don't have one):
+
+   ```bash
+   ssh-keygen -t ed25519 -C "crdm-tools-deploy-key" -f ~/.ssh/crdm_deploy_key
+   ```
+
+2. Add the public key as a deploy key to both repositories:
+   - Go to `https://github.com/uclh-criu/omop_es/settings/keys`
+   - Click "Add deploy key"
+   - Paste contents of `~/.ssh/crdm_deploy_key.pub`
+   - Grant read-only access
+   - Repeat for `https://github.com/uclh-criu/omop-cascade`
+
+### Local Development Setup
+
+For Docker builds to work, ensure your SSH key is loaded:
+
+```bash
+# Start SSH agent
+eval "$(ssh-agent -s)"
+
+# Add your key
+ssh-add ~/.ssh/crdm_deploy_key
+
+# Verify access
+ssh -T git@github.com
+
+# Build with SSH forwarding
+docker compose build omop_es
+```
+
+Docker BuildKit automatically forwards your SSH agent to build containers.
+
+### GAE Setup
+
+On each GAE instance:
+
+1. Copy the private key to the GAE:
+
+   ```bash
+   scp ~/.ssh/crdm_deploy_key user@gae-host:~/.ssh/id_ed25519
+   ```
+
+2. Set proper permissions:
+
+   ```bash
+   chmod 600 ~/.ssh/id_ed25519
+   ```
+
+3. Add to SSH agent:
+
+   ```bash
+   eval "$(ssh-agent -s)"
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+4. For persistent agent, add to `~/.bashrc` or use a systemd service.
+
+### GitHub Actions Setup
+
+The deploy key private key is stored as a GitHub Actions secret (`OMOP_ES_DEPLOY_KEY`). This is
+automatically configured in CI/CD workflows.

--- a/docs/ssh-deploy-keys.md
+++ b/docs/ssh-deploy-keys.md
@@ -29,11 +29,12 @@ ssh-add ~/.ssh/crdm_deploy_key
 # Verify access
 ssh -T git@github.com
 
-# Build with SSH forwarding
-docker compose build omop_es
+# Build with SSH forwarding (BuildKit must be enabled)
+DOCKER_BUILDKIT=1 docker compose build omop_es
 ```
 
-Docker BuildKit automatically forwards your SSH agent to build containers.
+Docker BuildKit automatically forwards your SSH agent to build containers when enabled with
+`DOCKER_BUILDKIT=1`.
 
 ### GAE Setup
 

--- a/docs/ssh-deploy-keys.md
+++ b/docs/ssh-deploy-keys.md
@@ -17,7 +17,7 @@
 
 ### Local Development Setup
 
-For Docker builds to work, ensure your SSH key is loaded:
+For both Docker builds and runtime operations to work, ensure your SSH key is loaded:
 
 ```bash
 # Start SSH agent
@@ -31,10 +31,14 @@ ssh -T git@github.com
 
 # Build with SSH forwarding (BuildKit must be enabled)
 DOCKER_BUILDKIT=1 docker compose build omop_es
+
+# Run container (SSH agent is automatically forwarded at runtime)
+docker compose run omop_es
 ```
 
 Docker BuildKit automatically forwards your SSH agent to build containers when enabled with
-`DOCKER_BUILDKIT=1`.
+`DOCKER_BUILDKIT=1`. At runtime, the `SSH_AUTH_SOCK` environment variable is mounted into the
+container to allow git operations (e.g., fetching updates, checking out refs).
 
 ### GAE Setup
 
@@ -59,7 +63,18 @@ On each GAE instance:
    ssh-add ~/.ssh/id_ed25519
    ```
 
-4. For persistent agent, add to `~/.bashrc` or use a systemd service.
+4. For persistent agent across reboots, create a systemd user service or add to shell profile:
+
+   ```bash
+   # Add to ~/.bashrc or ~/.profile
+   if [ -z "$SSH_AUTH_SOCK" ]; then
+       eval "$(ssh-agent -s)"
+       ssh-add ~/.ssh/id_ed25519 2>/dev/null
+   fi
+   ```
+
+   **Important**: The SSH agent must be running before starting Docker containers, as the
+   `SSH_AUTH_SOCK` socket is mounted into containers at runtime for git operations.
 
 ### GitHub Actions Setup
 

--- a/prefect/run_omop_es.py
+++ b/prefect/run_omop_es.py
@@ -19,10 +19,9 @@ import re
 import subprocess
 from pathlib import Path
 
-import dotenv
-from prefect import flow, logging, runtime, task
-
 from run_subprocess import run_subprocess
+
+from prefect import flow, logging, runtime, task
 
 ROOT_PATH = Path(__file__).parents[1]
 DEPLOYMENT_NAME = str(runtime.deployment.name).lower()
@@ -83,6 +82,7 @@ def run_omop_es(
 def pin_omop_es_version(ref: str) -> str:
     """
     Finds the latest commit hash for the given OMOP_ES ref.
+    Uses SSH authentication (requires SSH key configured on host).
 
     Args:
         ref: The OMOP_ES ref to find the latest commit hash for. Can be a branch, tag, or commit SHA.
@@ -90,13 +90,7 @@ def pin_omop_es_version(ref: str) -> str:
     Returns:
         The latest commit hash for the given OMOP_ES ref.
     """
-    dotenv.load_dotenv(ROOT_PATH / ".env")
-    github_pat = os.environ.get("GITHUB_PAT")
-    if not github_pat:
-        raise ValueError("GITHUB_PAT environment variable not set")
-    omop_es_url = (
-        f"https://x-access-token:{github_pat}@github.com/uclh-criu/omop_es.git"
-    )
+    omop_es_url = "git@github.com:uclh-criu/omop_es.git"
 
     try:
         sha = get_latest_commit_sha(omop_es_url, ref)

--- a/template.env
+++ b/template.env
@@ -9,9 +9,10 @@ USER_PWD=
 # Group ID for docker:docker on the GAE, needed at container build time
 DOCKER_USER_GID=993
 
-# Create token for omop_es and omop-cascade repos:
-# https://github.com/settings/tokens/new
-# GITHUB_PAT=
+# SSH Deploy Key Authentication
+# For Docker builds: Ensure SSH agent is running with key loaded
+# For GAE: Configure SSH key in ~/.ssh/id_ed25519 or use ssh-agent
+# See README.md for detailed setup instructions
 
 # renv cache
 RENV_PATHS_CACHE_HOST=./.cache/renv


### PR DESCRIPTION
**Work in progress**: preliminary implementation, still needs extensive testing, especially on GAE and CI.

Fixes #71

### To do

- [ ] Add deploy keys to `uclh-criu/omop_es` and `uclh-criu/omop-cascade` repos (by someone with admin access) --> For both GAE keys and local dev keys
- [ ] Add private key as `secret` to `uclh-criu/crdm-tools` repo and its public key as deploy key in `omop_es` and `omop-cascade`, for CI

### To test

- [x] Docker build for omop_es succeeds locally
- [ ] Docker build for omop-cascade succeeds locally
- [ ] Prefect workflow can validate git refs
- [ ] GitHub Actions docker-build workflow passes
- [ ] GitHub Actions prefect-flow-tests workflow passes
- [ ] Builds work on GAE instances
- [ ] Documentation is clear and complete


