### PR TITLE
prefect: add concurrency limit for omop es

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -51,7 +51,7 @@ deployments:
           ENVIRONMENT: dev
 
   - name: omop_es-prod
-    concurrency_limit: 1
+    concurrency_limit: 2
     version:
     tags: [prod]
     description: Production deployment - configure omop_es_version parameter when deploying

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -51,6 +51,7 @@ deployments:
           ENVIRONMENT: dev
 
   - name: omop_es-prod
+    concurrency_limit: 1
     version:
     tags: [prod]
     description: Production deployment - configure omop_es_version parameter when deploying


### PR DESCRIPTION
Adding deployment [concurrency limit](https://docs.prefect.io/v3/how-to-guides/deployments/prefect-yaml#concurrency-limit-fields). Looks like we can run two runs concurrently from current set of runs